### PR TITLE
Disable EEPROMex debug mode

### DIFF
--- a/Libraries/EEPROMEx/EEPROMex.cpp
+++ b/Libraries/EEPROMEx/EEPROMex.cpp
@@ -27,7 +27,7 @@
  ******************************************************************************/
 
  #define _EEPROMEX_VERSION 1 // software version of this library
- #define _EEPROMEX_DEBUG     // Enables logging of maximum of writes and out-of-memory
+ //#define _EEPROMEX_DEBUG     // Enables logging of maximum of writes and out-of-memory
 /******************************************************************************
  * Constructors
  ******************************************************************************/


### PR DESCRIPTION
This reduces memory usage and allows >100 EEPROM writes.
